### PR TITLE
Npm version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ git clone -b gh-pages https://github.com/bollwyvl/nb-mermaid.git \
 In the notebook...
 ```javascript
 %%javascript
-IPython.load_ipython_extensions(["nb-mermaid/nb-mermaid"]);
+import notebook
+notebook.nbextensions.check_nbextension('nb-mermaid',user=True)
+require(['base/js/utils'],
+function(utils) {
+        utils.load_extensions('nb-mermaid/nb-mermaid');
+});
 ```
 
 
@@ -35,3 +40,12 @@ IPython.load_ipython_extensions(["nb-mermaid/nb-mermaid"]);
 - pan/zoom
 - search
 
+## Build assets
+Grab the Mermaid library
+```
+bower install
+```
+Run coffee and less to generate the 
+```
+npm run build
+```

--- a/README.md
+++ b/README.md
@@ -47,5 +47,6 @@ bower install
 ```
 Run coffee and less to generate the 
 ```
+npm install
 npm run build
 ```

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "nb-mermaid",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "authors": [
     "Nicholas Bollweg <nick.bollweg@gmail.com>"
   ],
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "mermaid": "~0.5.1"
+    "mermaid": "~6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   },
   "description": "",
   "devDependencies": {
-    "coffee-script": "~1.9.2",
-    "less": "~2.5.0",
-    "watch": "~0.16.0",
+    "coffee-script": "~1.10.0",
+    "less": "~2.7.0",
+    "watch": "~0.18.0",
     "less-plugin-autoprefix": "~1.4.2",
     "jade": "~1.11.0",
-    "marked": "~0.3.3",
-    "jstransformer-marked": "0.0.2"
+    "marked": "~0.3.5",
+    "jstransformer-marked": "1.0.0"
   },
   "license": "BSD",
   "main": "main.js",
@@ -21,11 +21,13 @@
     "url": "https://github.com/bollwyvl/nb-mermaid.git"
   },
   "scripts": {
+    "build": "npm run coffee_build && npm run less",
+    "coffee_build": "./node_modules/.bin/coffee -c -o ./mermaid/static/nb-mermaid ./mermaid/static/src/*.coffee",
     "coffee": "./node_modules/.bin/coffee -cw -o ./mermaid/static/nb-mermaid ./mermaid/static/src/*.coffee",
     "less": "./node_modules/.bin/lessc ./mermaid/static/src/nb-mermaid.less ./mermaid/static/nb-mermaid/nb-mermaid.css  --autoprefix",
     "watch-less": "./node_modules/.bin/watch 'npm run less' ./mermaid/static/src",
     "jade": "./node_modules/.bin/jade --watch ./mermaid/static/src/*.jade -o ./mermaid/static/nb-mermaid",
     "live": "./bin/npm_watch_multiple.sh watch-less coffee jade"
   },
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/setup.json
+++ b/setup.json
@@ -17,7 +17,7 @@
   "description": "Mermaid diagrams in the IPython Notebook",
   "include_package_data": true,
   "install_requires": [
-    "IPython>3.0,<4.0",
+    "IPython>3.0",
     "jupyter-pip"
   ],
   "keywords": "IPython mermaid diagram",
@@ -27,9 +27,9 @@
     "mermaid"
   ],
   "setup_requires": [
-    "IPython>3.0,<4.0",
+    "IPython>3.0",
     "jupyter-pip"
   ],
   "url": "http://github.com/bollwyvl/nb-mermaid",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
Thanks for this module, I've been playing with it and it is a lot of fun!

I found that I couldn't install it via pip from PyPI, it would install IPython<4.0 as a dependency which was breaking because I was running inside Jupyter. I tried building from the current master branch, but was getting the following error

```
> lessc ./mermaid/static/src/nb-mermaid.less ./mermaid/static/nb-mermaid/nb-mermaid.css  --autoprefix

(node:8672) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.
```

I bumped the less version in this pull request along with some other package versions (including Mermaid itself to 6.0.0) - nothing seemed to break :-)

I've tested things manually as

```
bower install
npm install
npm run build
python setup.py sdist
pip install dist/nb-mermaid-0.1.1.tar.gz --user
```

Everything seems to be OK.
